### PR TITLE
Add support for custom protoc plugins in generator configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ default for both.
 If you want to use custom generators (not just the python, gRPC and pyi ones built in to
 the version of protoc that ships with grpcio-tools), you can add them in
 `[[tool.hatch.build.hooks.protobuf.generators]]` sections. You will also need to add the
-plugin to the list of dependencies. See the "Mypy output" section below for an example.
+plugin to the list of dependencies.
+
 Options that can be set in generator sections:
 
 | Key | Default | Description |
@@ -44,6 +45,7 @@ Options that can be set in generator sections:
 | `name` | required | The name of the plugin. The argument passed to protoc will be `--<name>_out`. |
 | `outputs` | required | A list of paths (relative to `output_path`). See below for more information. |
 | `output_path` | same as `output_path` from the main `protobuf` config section | Where to write generated files to. This is the value passed to the `--<name>_out` argument. |
+| `protoc_plugin` | `None` | The protoc plugin to use for this generator, if any. Will be passed as --plugin to protoc. This is useful for plugins that are not installed in the Python environment. |
 
 Each entry in the `outputs` field is a template that depends on the `.proto` file being
 processed. The string `{proto_name}` will be replaced with the base filename of each input .proto
@@ -51,6 +53,16 @@ file, and `{proto_path}` will be replaced with the path (relative to the proto_p
 the input proto files. For example, if `proto_paths` is set to `["src"]`, for the
 input file `src/foo/bar/test.proto` "{proto_name}" will expand to "test" and
 "{proto_path}" will expand to "foo/bar".
+
+Here is an example using the TypeScript generator:
+
+```
+[[tool.hatch.build.hooks.protobuf.generators]]
+name = "ts"
+outputs = ["{proto_path}/{proto_name}.ts"]
+output_path = "./frontend/src"
+protoc_plugin = "./frontend/node_modules/.bin/protoc-gen-ts_proto"
+```
 
 ### Mypy output
 

--- a/src/hatch_protobuf/plugin.py
+++ b/src/hatch_protobuf/plugin.py
@@ -27,6 +27,7 @@ class Generator:
     This is useful for plugins that are not installed in the Python environment."""
     protoc_plugin: Optional[Path] = None
 
+
 @dataclass
 class Files:
     inputs: List[Path]
@@ -56,7 +57,9 @@ class ProtocHook(BuildHookInterface):
             args.append(get_path("purelib"))
         for generator in self._generators:
             if generator.protoc_plugin:
-                args.append(f"--plugin=protoc-gen-{generator.name}={generator.protoc_plugin}")
+                args.append(
+                    f"--plugin=protoc-gen-{generator.name}={generator.protoc_plugin}"
+                )
             args.append(f"--{generator.name}_out={generator.output_path}")
 
         args += [str(p) for p in self._files.inputs]  # cast to str for debug output

--- a/src/hatch_protobuf/plugin.py
+++ b/src/hatch_protobuf/plugin.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
 from sysconfig import get_path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
@@ -23,6 +23,9 @@ class Generator:
     """Where to write output files."""
     output_path: Path
 
+    """The protoc plugin to use for this generator, if any. Will be passed as --plugin to protoc.
+    This is useful for plugins that are not installed in the Python environment."""
+    protoc_plugin: Optional[Path] = None
 
 @dataclass
 class Files:
@@ -52,6 +55,8 @@ class ProtocHook(BuildHookInterface):
             args.append("--proto_path")
             args.append(get_path("purelib"))
         for generator in self._generators:
+            if generator.protoc_plugin:
+                args.append(f"--plugin=protoc-gen-{generator.name}={generator.protoc_plugin}")
             args.append(f"--{generator.name}_out={generator.output_path}")
 
         args += [str(p) for p in self._files.inputs]  # cast to str for debug output
@@ -128,6 +133,7 @@ class ProtocHook(BuildHookInterface):
                     name=g["name"],
                     outputs=g["outputs"],
                     output_path=Path(g.get("output_path", output_path)),
+                    protoc_plugin=g.get("protoc_plugin", None),
                 )
             )
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and modifications to the `src/hatch_protobuf/plugin.py` file to support custom protoc plugins.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R48): Added a new configuration option `protoc_plugin` to the generator sections and provided an example using the TypeScript generator. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R66)

Code updates for custom protoc plugins:

* [`src/hatch_protobuf/plugin.py`](diffhunk://#diff-1022e6f0830d38875f94c0016eb1a358d09e3b42a5ab77b9bc3e5ce209591a0cR26-R28): Added a new attribute `protoc_plugin` to the `Generator` class to specify the protoc plugin path.
* [`src/hatch_protobuf/plugin.py`](diffhunk://#diff-1022e6f0830d38875f94c0016eb1a358d09e3b42a5ab77b9bc3e5ce209591a0cR58-R59): Modified the `initialize` method to include the `protoc_plugin` argument when invoking protoc, if provided.
* [`src/hatch_protobuf/plugin.py`](diffhunk://#diff-1022e6f0830d38875f94c0016eb1a358d09e3b42a5ab77b9bc3e5ce209591a0cR136): Updated the `_generators` method to read the `protoc_plugin` configuration from the generator sections.