### PR TITLE
Add support for library_paths to include additional proto directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ section:
 | --- | ------- | ----------- |
 | `generate_grpc` | `true` | Whether to generate gRPC output files. |
 | `generate_pyi` | `true` | Whether to generate .pyi output files. Note that these are not generated for the gRPC output. You may want to use mypy-protobuf instead. |
-| `import_site_packages` | `false` | Adds your Python `site-packages` directory to `--proto_path`, so you can [`import` `.proto` files from installed Python packages](#include-proto-files-from-site-packages). This *does not* add individual `.proto` files in `site-packages` as arguments to `protoc`. |
+| `import_site_packages` | `false` | Adds your Python `site-packages` directory to `--proto_path`, so you can [`import` `.proto` files from installed Python packages](#import-proto-files-from-site-packages). This *does not* add individual `.proto` files in `site-packages` as arguments to `protoc`. |
 | `proto_paths` | `["."]` or `["src"]` | An array of paths to search for `.proto` files. Also passed as `--proto_path` arguments to `protoc`. This does not follow symlinks. |
 | `output_path` | `"."` or `"src"` | The default output directory. This can be overridden on a per-generator basis for custom generators. |
+| `library_paths` | `[]` | Similar to `proto_paths`, but **without** building the `_pb2.py` files, allowing imports from `.proto`s not included in the Python `site-packages` directory. |
 
 Hatch-protobuf will guess whether to use "src" as the default input/output directory in
 a similar way to the [wheel builder][wheel-builder-defaults]. If
@@ -165,3 +166,15 @@ package, and stomp all over your `site-packages` directory.
 > *Editable* dependencies (eg: installed with `pip install -e` or using
 > [`uv` workspaces](https://docs.astral.sh/uv/concepts/projects/dependencies/#editable-dependencies))
 > use a different directory layout which can't be imported from by `protoc`.
+
+To consume Protocol Buffer definitions from published Python packages which
+include only `_pb2.py` files, `library_paths` can be set to the directory
+containing the `.proto` files.
+For example, You can add [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto)
+as a submodule in a project, and you will be able to import files from it after
+including the following config:
+
+```
+[tool.hatch.build.hooks.protobuf]
+library_paths = ["./libs/opentelemetry-proto"]
+```

--- a/src/hatch_protobuf/plugin.py
+++ b/src/hatch_protobuf/plugin.py
@@ -86,6 +86,9 @@ class ProtocHook(BuildHookInterface):
         for path in self._proto_paths:
             args.append("--proto_path")
             args.append(path)
+        for path in self._library_paths:
+            args.append("--proto_path")
+            args.append(path)
         if self._get_bool_conf("import_site_packages", False):
             args.append("--proto_path")
             args.append(get_path("purelib"))
@@ -144,6 +147,10 @@ class ProtocHook(BuildHookInterface):
     @cached_property
     def _proto_paths(self) -> List[str]:
         return self._get_list_of_str_conf("proto_paths", [self._default_proto_path])
+
+    @cached_property
+    def _library_paths(self) -> List[str]:
+        return self._get_list_of_str_conf("library_paths", [])
 
     @cached_property
     def _generators(self) -> List[Generator]:


### PR DESCRIPTION
This pull request introduces a new configuration option, `library_paths`, to enhance the flexibility of handling Protocol Buffer definitions in Python projects. The changes primarily focus on updating documentation and implementing support for the new option in the plugin code.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R25): Added a description for the new `library_paths` option, explaining its purpose and usage. This option allows importing `.proto` files from directories that are not included in the Python `site-packages`, without generating `_pb2.py` files. An example configuration for using `library_paths` with `opentelemetry-proto` was also provided. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R169-R180)

### Plugin implementation:

* [`src/hatch_protobuf/plugin.py`](diffhunk://#diff-1022e6f0830d38875f94c0016eb1a358d09e3b42a5ab77b9bc3e5ce209591a0cR89-R91): Updated the `initialize` method to include `library_paths` in the `--proto_path` arguments passed to `protoc`.
* [`src/hatch_protobuf/plugin.py`](diffhunk://#diff-1022e6f0830d38875f94c0016eb1a358d09e3b42a5ab77b9bc3e5ce209591a0cR151-R154): Added a new cached property, `_library_paths`, to retrieve the `library_paths` configuration from the plugin settings.